### PR TITLE
Support permission usage stats API for Android P

### DIFF
--- a/opsxlib/src/main/java/com/zzzmode/appopsx/common/OpEntry.java
+++ b/opsxlib/src/main/java/com/zzzmode/appopsx/common/OpEntry.java
@@ -3,39 +3,87 @@ package com.zzzmode.appopsx.common;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import java.util.Arrays;
+
 public class OpEntry implements Parcelable {
 
   private final int mOp;
   private final int mMode;
-  private final long mTime;
-  private final long mRejectTime;
+  private final long[] mTimes;
+  private final long[] mRejectTimes;
   private final int mDuration;
   private final int mProxyUid;
+  private final boolean mRunning;
   private final String mProxyPackageName;
 
   /**
-   * {@see https://github.com/LineageOS/android_frameworks_base/blob/cm-14.1/core/java/android/app/AppOpsManager.java}
+   * {@see https://github.com/LineageOS/android_frameworks_base/blob/lineage-16.0/core/java/android/app/AppOpsManager.java}
    */
   private final int mAllowedCount;
   private final int mIgnoredCount;
+
+  // Metrics about an op when its uid is persistent.
+  public static final int UID_STATE_PERSISTENT = 0;
+  // Metrics about an op when its uid is at the top.
+  public static final int UID_STATE_TOP = 1;
+  // Metrics about an op when its uid is running a foreground service.
+  public static final int UID_STATE_FOREGROUND_SERVICE = 2;
+  // Last UID state in which we don't restrict what an op can do.
+  public static final int UID_STATE_LAST_NON_RESTRICTED = UID_STATE_FOREGROUND_SERVICE;
+  // Metrics about an op when its uid is in the foreground for any other reasons.
+  public static final int UID_STATE_FOREGROUND = 3;
+  // Metrics about an op when its uid is in the background for any reason.
+  public static final int UID_STATE_BACKGROUND = 4;
+  // Metrics about an op when its uid is cached.
+  public static final int UID_STATE_CACHED = 5;
+  // Number of uid states we track.
+  public static final int _NUM_UID_STATE = 6;
 
   public OpEntry(int op, int mode, long time, long rejectTime, int duration,
       int proxyUid, String proxyPackage,int allowedCount,int ignoredCount) {
     mOp = op;
     mMode = mode;
-    mTime = time;
-    mRejectTime = rejectTime;
+    mTimes = new long[_NUM_UID_STATE];
+    mRejectTimes = new long[_NUM_UID_STATE];
+    mTimes[0] = time;
+    mRejectTimes[0] = rejectTime;
     mDuration = duration;
+    mRunning = duration == -1;
     mProxyUid = proxyUid;
     mProxyPackageName = proxyPackage;
     mAllowedCount = allowedCount;
     mIgnoredCount = ignoredCount;
   }
 
-  public OpEntry(int op, int mode, long time, long rejectTime, int duration,
-      int proxyUid, String proxyPackage) {
-    this(op,mode,time,rejectTime,duration,proxyUid,proxyPackage,0,0);
+  public OpEntry(int op, int mode, long[] times, long[] rejectTimes, int duration,
+                 boolean running, int proxyUid, String proxyPackage,
+                 int allowedCount, int ignoredCount) {
+    mOp = op;
+    mMode = mode;
+    mTimes = new long[_NUM_UID_STATE];
+    mRejectTimes = new long[_NUM_UID_STATE];
+    System.arraycopy(times, 0, mTimes, 0, _NUM_UID_STATE);
+    System.arraycopy(rejectTimes, 0, mRejectTimes, 0, _NUM_UID_STATE);
+    mDuration = duration;
+    mRunning = running;
+    mProxyUid = proxyUid;
+    mProxyPackageName = proxyPackage;
+    mAllowedCount = allowedCount;
+    mIgnoredCount = ignoredCount;
   }
+
+  public OpEntry(int op, int mode, long[] times, long[] rejectTimes, int duration,
+                 int proxyUid, String proxyPackage, int allowedCount, int ignoredCount) {
+    this(op, mode, times, rejectTimes, duration, duration == -1, proxyUid, proxyPackage,
+            allowedCount, ignoredCount);
+  }
+
+  public OpEntry(int op, int mode, long time, long rejectTime, int duration,
+                 int proxyUid, String proxyPackage) {
+    this(op, mode, time, rejectTime, duration, proxyUid, proxyPackage,
+            0, 0);
+  }
+
 
   public int getOp() {
     return mOp;
@@ -46,11 +94,11 @@ public class OpEntry implements Parcelable {
   }
 
   public long getTime() {
-    return mTime;
+    return maxTime(mTimes, 0, _NUM_UID_STATE);
   }
 
   public long getRejectTime() {
-    return mRejectTime;
+    return maxTime(mRejectTimes, 0, _NUM_UID_STATE);
   }
 
   public boolean isRunning() {
@@ -58,7 +106,7 @@ public class OpEntry implements Parcelable {
   }
 
   public int getDuration() {
-    return mDuration == -1 ? (int) (System.currentTimeMillis() - mTime) : mDuration;
+    return mDuration;
   }
 
   public int getProxyUid() {
@@ -82,8 +130,8 @@ public class OpEntry implements Parcelable {
     return "OpEntry{" +
         "mOp=" + mOp +
         ", mMode=" + mMode +
-        ", mTime=" + mTime +
-        ", mRejectTime=" + mRejectTime +
+        ", mTime=" + Arrays.toString(mTimes) +
+        ", mRejectTime=" + Arrays.toString(mRejectTimes) +
         ", mDuration=" + mDuration +
         ", mProxyUid=" + mProxyUid +
         ", mProxyPackageName='" + mProxyPackageName + '\'' +
@@ -99,9 +147,10 @@ public class OpEntry implements Parcelable {
   public void writeToParcel(Parcel dest, int flags) {
     dest.writeInt(this.mOp);
     dest.writeInt(this.mMode);
-    dest.writeLong(this.mTime);
-    dest.writeLong(this.mRejectTime);
+    dest.writeLongArray(this.mTimes);
+    dest.writeLongArray(this.mRejectTimes);
     dest.writeInt(this.mDuration);
+    dest.writeByte((byte) (this.mRunning ? 1 : 0));
     dest.writeInt(this.mProxyUid);
     dest.writeString(this.mProxyPackageName);
     dest.writeInt(this.mAllowedCount);
@@ -111,13 +160,24 @@ public class OpEntry implements Parcelable {
   protected OpEntry(Parcel in) {
     this.mOp = in.readInt();
     this.mMode = in.readInt();
-    this.mTime = in.readLong();
-    this.mRejectTime = in.readLong();
+    this.mTimes = in.createLongArray();
+    this.mRejectTimes = in.createLongArray();
     this.mDuration = in.readInt();
+    this.mRunning = in.readByte() != 0;
     this.mProxyUid = in.readInt();
     this.mProxyPackageName = in.readString();
     this.mAllowedCount = in.readInt();
     this.mIgnoredCount = in.readInt();
+  }
+
+  public static long maxTime(long[] times, int start, int end) {
+    long time = 0;
+    for (int i = start; i < end; i++) {
+      if (times[i] > time) {
+        time = times[i];
+      }
+    }
+    return time;
   }
 
   public static final Creator<OpEntry> CREATOR = new Creator<OpEntry>() {

--- a/opsxlib/src/main/java/com/zzzmode/appopsx/common/ReflectUtils.java
+++ b/opsxlib/src/main/java/com/zzzmode/appopsx/common/ReflectUtils.java
@@ -38,8 +38,8 @@ public class ReflectUtils {
       for (Object o : list) {
         int mOp = getIntFieldValue(o, "mOp");
         int mMode = getIntFieldValue(o, "mMode");
-        long mTime = getLongFieldValue(o, "mTime");
-        long mRejectTime = getLongFieldValue(o, "mRejectTime");
+        long mTime = (long) invokMethod(o, "getTime", null, null);
+        long mRejectTime = (long) invokMethod(o, "getRejectTime", null, null);
         int mDuration = getIntFieldValue(o, "mDuration");
         int mProxyUid = getIntFieldValue(o, "mProxyUid");
         String mProxyPackageName = String.valueOf(getFieldValue(o, "mProxyPackageName"));


### PR DESCRIPTION
Fix #45. However, this PR may NOT work on older Android version as I noticed the serialization procedures are provided locally instead of reflected so we may need different `OpEntry` classes for both 9.0 and below 9.0. I do not expertise in Android developing so I have no idea how to maintain backward compatibility.... So this may be just a WFM solution, at least last usage timestamp functional tested from Android 9.

Hoping for suggestions 😄 

![image](https://user-images.githubusercontent.com/2762704/51490852-750dcb80-1de7-11e9-8e85-dd137af6ee80.png)
